### PR TITLE
Append any initialization options to the generated initialization output

### DIFF
--- a/appfy/recipe/gae/tools.py
+++ b/appfy/recipe/gae/tools.py
@@ -134,6 +134,9 @@ class Recipe(zc.recipe.egg.Scripts):
         initialization.append('gae = %s' % self.get_path(self.sdk_dir))
         initialization.append('cfg = %s' % self.get_path(self.config_file))
 
+        if 'initialization' in self.options:
+            initialization.append(self.options['initialization'])
+
         self.options.update({
             'entry-points':   ' '.join(entry_points),
             'initialization': '\n'.join(initialization),


### PR DESCRIPTION
Resolves #8 by appending initialization to the rest of the initialization code

Example buildout.cfg section

```
[gae_tools]
recipe = appfy.recipe.gae:tools
sdk-directory = ${gae_sdk:destination}/google_appengine
initialization =
    import dev_appserver
    dev_appserver.fix_sys_path()
extra-paths =
    ${buildout:gae-deploy-dir}
    ${buildout:gae-deploy-dir}/dist
    ${buildout:directory}/local_appserver_deps
```
