### PR TITLE
Fetch the latest SDK version if 'url' is not specified. Documentation fixes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,8 @@ Downloads and installs the App Engine SDK in the buildout directory.
 Options
 ~~~~~~~
 
-:url: URL to the App Engine SDK file.
+:url: URL to the App Engine SDK file. Default is to download the latest version
+    from storage.googleapis.com.
 :destination: Destination of the extracted SDK. Default is the parts directory.
 :clear-destination: If `true`, deletes the destination dir before
     extracting the download. Default is `true`.

--- a/appfy/recipe/gae/sdk.py
+++ b/appfy/recipe/gae/sdk.py
@@ -8,7 +8,8 @@ Downloads and installs the App Engine SDK in the buildout directory.
 Options
 ~~~~~~~
 
-:url: URL to the App Engine SDK file.
+:url: URL to the App Engine SDK file. Default is to download the latest version
+    from storage.googleapis.com.
 :destination: Destination of the extracted SDK. Default is the parts directory.
 :clear-destination: If `true`, deletes the destination dir before
     extracting the download. Default is `true`.
@@ -27,6 +28,10 @@ Example
   clear-destination = true
 """
 import os
+import urllib2
+import xml.etree.ElementTree as et
+import distutils.version as version
+import re
 
 from appfy.recipe.download import Recipe as DownloadRecipe
 
@@ -37,3 +42,23 @@ class Recipe(DownloadRecipe):
         options.setdefault('destination', parts_dir)
         options.setdefault('clear-destination', 'true')
         super(Recipe, self).__init__(buildout, name, options)
+
+    def install(self):
+        if self.option_url is None:
+            self.option_url = self.find_latest_sdk_url()
+            self.logger.info('Using latest GAE SDK from "{}"'.format(self.option_url))
+        super(Recipe, self).install()
+
+    def find_latest_sdk_url(self):
+        base = 'https://storage.googleapis.com/appengine-sdks/'
+        ns = '{http://doc.s3.amazonaws.com/2006-03-01}'
+        featured_re = re.compile(r'featured/google_appengine_(\d+\.\d+\.\d+).zip')
+
+        tree = et.parse(urllib2.urlopen(base))
+        keys = (contents.find(ns + 'Key') for contents in tree.getroot().findall(ns + 'Contents'))
+        candidates = ((el, featured_re.match(el.text)) for el in keys)
+        candidates = ((el, match.group(1)) for el, match in candidates if not match is None)
+        candidates = ((el, version.StrictVersion(version_str)) for el, version_str in candidates)
+        latest = sorted(candidates, key=lambda tup: tup[1])[-1]
+        return ''.join([base, latest[0].text])
+

--- a/appfy/recipe/gae/tools.py
+++ b/appfy/recipe/gae/tools.py
@@ -31,6 +31,8 @@ Options
 :config-file: Configuration file with the default values to use in
     scripts. Default is `gaetools.cfg`.
 :extra-paths: Extra paths to include in sys.path for generated scripts.
+:initialization: Allows to specify some Python code to be included in
+    the scripts.
 
 Example
 ~~~~~~~
@@ -41,7 +43,10 @@ Example
   # Installs appcfg, dev_appserver and python executables in the bin directory.
   recipe = appfy.recipe.gae:tools
   sdk-directory = ${gae_sdk:destination}/google_appengine
-
+  # add extra code
+  initialization =
+    import dev_appserver
+    dev_appserver.fix_sys_path()
   # Add these paths to sys.path in the generated scripts.
   extra-paths =
       app/lib

--- a/create_readme.py
+++ b/create_readme.py
@@ -3,7 +3,7 @@ import os
 join   = os.path.join
 BASE   = os.path.abspath(os.path.realpath(os.path.dirname(__file__)))
 GAE    = join(BASE, 'appfy', 'recipe', 'gae')
-README = join(BASE, 'README.txt')
+README = join(BASE, 'README.rst')
 FILES  = [
     join(BASE, 'setup.py'),
     join(GAE, 'app_lib.py'),

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 appfy.recipe.gae
 ================
 
+.. image:: https://travis-ci.org/prmtl/appfy.recipe.gae.png?branch=master
+   :target: https://travis-ci.org/prmtl/appfy.recipe.gae
+
 `appfy.recipe.gae` provides a series of `zc.buildout <http://pypi.python.org/pypi/zc.buildout>`_
 recipes to help with `Google App Engine <http://code.google.com/appengine/>`_
 development. It is inspired by `rod.recipe.appengine <http://pypi.python.org/pypi/rod.recipe.appengine>`_,


### PR DESCRIPTION
Google have changed their downloads so that older versions are no longer accessible without logging in and no longer have long-lasting, fixed URLs. This causes our Buildout scripts to break all the time.

This pull request allows us to skip the 'url' option, in which case the recipe will simply fetch the latest version of the SDK and install that. Users who _do_ specify a 'url' explicitly are unaffected.

Related issue on the App Engine issue tracker - https://code.google.com/p/googleappengine/issues/detail?id=10840.

Also, there are a few documentation fixes here and there.
