### PR TITLE
Wait to check for an empty sdk url until install time

### DIFF
--- a/appfy/recipe/gae/sdk.py
+++ b/appfy/recipe/gae/sdk.py
@@ -62,12 +62,13 @@ class Recipe(download.Recipe):
         options.setdefault('destination', parts_dir)
         options.setdefault('clear-destination', 'true')
 
-        if options.get('url') is None:
-            options['url'] = self.find_latest_sdk_url()
-
-        self.logger.info('Using SDK version found at %s', options['url'])
-
         super(Recipe, self).__init__(buildout, name, options)
+
+    def install(self):
+        if not self.option_url:
+            self.option_url = self.find_latest_sdk_url()
+        self.logger.info('Using SDK version found at %s', self.option_url)
+        return super(Recipe, self).install()
 
     def find_latest_sdk_url(self):
         def version_key(sdk):


### PR DESCRIPTION
This prevents us from making http requests to determine the sdk version
when buildout is run for parts not including this recipe.

Fixes #17 
