### PR TITLE
Get latest SDK using https://appengine.google.com/api/updatecheck

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,11 @@ appfy.recipe.gae
 .. image:: https://travis-ci.org/prmtl/appfy.recipe.gae.png?branch=master
    :target: https://travis-ci.org/prmtl/appfy.recipe.gae
 
-`appfy.recipe.gae` provides a series of `zc.buildout <http://pypi.python.org/pypi/zc.buildout>`_
+`appfy.recipe.gae` provides a series of
+`zc.buildout <http://pypi.python.org/pypi/zc.buildout>`_
 recipes to help with `Google App Engine <http://code.google.com/appengine/>`_
-development. It is inspired by `rod.recipe.appengine <http://pypi.python.org/pypi/rod.recipe.appengine>`_,
+development. It is inspired by
+`rod.recipe.appengine <http://pypi.python.org/pypi/rod.recipe.appengine>`_,
 but using a different layout and with extended functionalities. It is also
 split in different recipes. Currently `appfy.recipe.gae` has 3 recipes:
 
@@ -18,7 +20,9 @@ split in different recipes. Currently `appfy.recipe.gae` has 3 recipes:
     dev_appserver and remote_api_shell. It also allows to set default values
     to start the dev_appserver.
 
-Source code and issue tracker can be found at `https://github.com/prmtl/appfy.recipe.gae <https://github.com/prmtl/appfy.recipe.gae>`_.
+Source code and issue tracker can be found at
+`https://github.com/prmtl/appfy.recipe.gae
+<https://github.com/prmtl/appfy.recipe.gae>`_.
 
 For an example of how appfy makes distribution of App Engine apps easy and
 nice, see `Moe installation instructions <http://www.tipfy.org/wiki/moe/>`_.
@@ -104,9 +108,10 @@ Example
 ::
 
   [gae_sdk]
-  # Dowloads and extracts the App Engine SDK.
+  # Downloads and extracts the App Engine SDK.
   recipe = appfy.recipe.gae:sdk
-  url = http://googleappengine.googlecode.com/files/google_appengine_1.3.5.zip
+  # Omit `url` to always use the latest from https://appengine.google.com/api/updatecheck
+  url = http://googleappengine.googlecode.com/files/google_appengine_1.9.11.zip
   destination = ${buildout:parts-directory}
   hash-name = false
   clear-destination = true
@@ -121,7 +126,8 @@ remote_api_shell.
 
 It also allows to set default values to start the dev_appserver.
 
-This recipe extends `zc.recipe.egg.Scripts <http://pypi.python.org/pypi/zc.recipe.egg>`_,
+This recipe extends
+`zc.recipe.egg.Scripts <http://pypi.python.org/pypi/zc.recipe.egg>`_,
 so all the options from that recipe are also valid.
 
 Options

--- a/appfy/recipe/gae/sdk.py
+++ b/appfy/recipe/gae/sdk.py
@@ -22,7 +22,8 @@ Example
   [gae_sdk]
   # Downloads and extracts the App Engine SDK.
   recipe = appfy.recipe.gae:sdk
-  # Omit `url` to always use the latest from https://appengine.google.com/api/updatecheck
+  # Omit `url` to always use the latest from
+  # https://appengine.google.com/api/updatecheck
   url = http://googleappengine.googlecode.com/files/google_appengine_1.9.11.zip
   destination = ${buildout:parts-directory}
   hash-name = false
@@ -49,7 +50,8 @@ class SDKCouldNotBeFound(Exception):
 class Recipe(download.Recipe):
 
     URL = "https://appengine.google.com/api/updatecheck"
-    PYTHON_SDK_URL_TPL = "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_{version}.zip"
+    PYTHON_SDK_URL_TPL = ("https://storage.googleapis.com/appengine-sdks/"
+                          "featured/google_appengine_{version}.zip")
 
     def __init__(self, buildout, name, options):
         self.logger = logging.getLogger(name)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setuptools.setup(
     install_requires=[
         'setuptools',
         'zc.buildout',
-        'zc.recipe.egg >= 2.0.0'
+        'zc.recipe.egg >= 2.0.0',
+        'PyYAML'
     ],
     entry_points={
         'zc.buildout': [


### PR DESCRIPTION
I added a dependency on PyYAML in order to parse the yaml output

```
(jj)Josh@kapbook:appfy.recipe.gae$ python
Python 2.7.6 (default, Sep  9 2014, 15:04:36)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.39)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import yaml
>>> import urllib2
>>> URL = "https://appengine.google.com/api/updatecheck"
>>> PYTHON_SDK_URL_TPL = "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_{version}.zip"
>>> update_check_yaml = urllib2.urlopen(URL).read()
>>> update_check = yaml.load(update_check_yaml)
>>> print update_check
{'release': '1.9.19', 'timestamp': 1424415497, 'supported_api_versions': {'python': {'api_versions': ['1']}, 'go': {'api_versions': ['go1']}, 'java7': {'api_versions': ['1.0']}, 'python27': {'api_versions': ['1']}}, 'api_versions': ['1']}
>>> PYTHON_SDK_URL_TPL.format(version=update_check['release'])
'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.19.zip'
```

Fixes https://github.com/prmtl/appfy.recipe.gae/issues/20
